### PR TITLE
Upgrade chromedriver to v2.40

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -77,7 +77,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 A
     rm -rf /usr/share/man/man7 && \
     echo 'gem: --no-document' > /etc/gemrc && \
     gem install bundler && \
-    curl -OLk https://chromedriver.storage.googleapis.com/2.37/chromedriver_linux64.zip && \
+    curl -OLk https://chromedriver.storage.googleapis.com/2.40/chromedriver_linux64.zip && \
     unzip chromedriver_linux64.zip && \
     mv chromedriver /usr/bin/chromedriver && \
     rm -f chromedriver_linux64.zip && \


### PR DESCRIPTION
Wercker seems to be using chrome 68 which is a mystery since we have
chrome 66 in the Dockerfiles. This PR will upgrade chromedriver to 2.40
who supports both chrome 66 and 68