### PR TITLE
Upgrade webdriver to 2.43 to support chrome 70

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -77,7 +77,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 A
     rm -rf /usr/share/man/man7 && \
     echo 'gem: --no-document' > /etc/gemrc && \
     gem install bundler && \
-    curl -OLk https://chromedriver.storage.googleapis.com/2.40/chromedriver_linux64.zip && \
+    curl -OLk https://chromedriver.storage.googleapis.com/2.43/chromedriver_linux64.zip && \
     unzip chromedriver_linux64.zip && \
     mv chromedriver /usr/bin/chromedriver && \
     rm -f chromedriver_linux64.zip && \


### PR DESCRIPTION
So apparently chrome has been update in our Docker images so now we need
webdriver 2.43 that supports chrome version 70.