### PR TITLE
Update build + ruby to 2.6.3

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 A
     echo deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main >> /etc/apt/sources.list.d/google.list && \
     apt-get update -q && apt-get upgrade -yq --no-install-recommends && \
 			apt-get install -yq --no-install-recommends \
+      tzdata \
       autoconf \
       g++ \
       gcc \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,36 +1,39 @@
-FROM ubuntu:14.04
-MAINTAINER Tim Flapper <tim@springest.com>
+FROM ubuntu:18.04
+MAINTAINER Springest <developers@springest.com>
 
-# Inspired by cloudgear ubuntu image (https://github.com/cloudgear-images/ubuntu)
-# Inspired by cloudgear ruby image (https://github.com/cloudgear-images/ruby)
-
-RUN locale-gen en_US.UTF-8 && \
-    update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8 && \
-    # Don't install man documents for future packages and remove existing
-    printf "path-exclude /usr/share/doc/*\npath-exclude /usr/share/man/*\npath-exclude /usr/share/info/*\npath-exclude /usr/share/lintian/*" >> /etc/dpkg/dpkg.cfg.d/nodoc && \
+RUN printf "path-exclude /usr/share/doc/*\npath-exclude /usr/share/man/*\npath-exclude /usr/share/info/*\npath-exclude /usr/share/lintian/*" >> /etc/dpkg/dpkg.cfg.d/nodoc && \
     cd /usr/share && rm -fr doc/* man/* info/* lintian/*
 
 ENV LANG      en_US.UTF-8
 ENV LANGUAGE  en_US.UTF-8
 ENV LC_ALL    en_US.UTF-8
 
-ENV RUBY_VERSION 2.4
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -q && apt-get install -yq --no-install-recommends ca-certificates apt-transport-https gnupg locales curl && \
+    locale-gen en_US.UTF-8 && \
+    echo deb https://apt.fullstaqruby.org ubuntu-18.04 main > /etc/apt/sources.list.d/fullstaq-ruby.list && \
+    curl -SLfO https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-server-edition/master/fullstaq-ruby.asc && \
+    apt-key add fullstaq-ruby.asc && \
+    apt update && \
+    apt-get install -yq --no-install-recommends fullstaq-ruby-2.6.3-jemalloc
+
+# Pick up new ruby/gem binaries
+ENV PATH="/usr/lib/fullstaq-ruby/versions/2.6.3-jemalloc/bin:${PATH}"
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 ABF5BD827BD9BF62 && \
-    echo deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main > /etc/apt/sources.list.d/pgdg.list && \
-    echo deb http://nginx.org/packages/ubuntu/ trusty nginx > /etc/apt/sources.list.d/nginx.list && \
-    echo deb http://ppa.launchpad.net/brightbox/ruby-ng/ubuntu trusty main > /etc/apt/sources.list.d/brightbox-ruby-ng-trusty.list && \
-    echo deb http://deb.nodesource.com/node_8.x trusty main > /etc/apt/sources.list.d/nodesource.list && \
+    echo deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main > /etc/apt/sources.list.d/pgdg.list && \
+    echo deb http://nginx.org/packages/ubuntu/ bionic nginx > /etc/apt/sources.list.d/nginx.list && \
+    echo deb http://deb.nodesource.com/node_8.x bionic main > /etc/apt/sources.list.d/nodesource.list && \
     echo deb http://dl.yarnpkg.com/debian/ stable main > /etc/apt/sources.list.d/yarn.list && \
     mkdir -p /usr/share/man/man1 && mkdir -p /usr/share/man/man7 && \
-    apt-get update -q && apt-get install -yq --no-install-recommends ca-certificates curl && \
-    curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    curl https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - && \
-    curl https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add - && \
-    curl https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - && \
+    curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    curl -s https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+    curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+    curl -s https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main >> /etc/apt/sources.list.d/google.list && \
     apt-get update -q && apt-get upgrade -yq --no-install-recommends && \
-    apt-get install -yq --no-install-recommends \
+			apt-get install -yq --no-install-recommends \
       autoconf \
       g++ \
       gcc \
@@ -51,8 +54,6 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 A
       libxslt-dev \
       libyaml-dev \
       zlib1g-dev \
-      ruby$RUBY_VERSION \
-      ruby$RUBY_VERSION-dev \
       build-essential \
       git \
       imagemagick \
@@ -74,37 +75,35 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 A
       libpq-dev \
       nginx \
       python-dev \
-      libjemalloc-dev \
       ghostscript \
       poppler-utils \
       tesseract-ocr && \
     rm -rf /usr/share/man/man1 && \
     rm -rf /usr/share/man/man7 && \
+    \
+    # Setup Rubygems
     echo 'gem: --no-document' > /etc/gemrc && \
     gem install bundler && \
-
+    \
     # Chromedriver
-    curl -OLk https://chromedriver.storage.googleapis.com/73.0.3683.68/chromedriver_linux64.zip && \
+    curl -sOLk https://chromedriver.storage.googleapis.com/77.0.3865.40/chromedriver_linux64.zip && \
     unzip chromedriver_linux64.zip && \
     mv chromedriver /usr/bin/chromedriver && \
     rm -f chromedriver_linux64.zip && \
-
+    \
     # Install AWS CLI to local user
-    curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
+    curl -s "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
     unzip awscli-bundle.zip && \
     ./awscli-bundle/install -b ~/bin/aws && \
     rm awscli-bundle.zip && \
     rm -r awscli-bundle && \
-
+    \
     # Update ImageMagick policy to allow `convert` to convert PDF files to TIFF for OCR
-    sed -i 's+<policy domain="coder" rights="none" pattern="PDF" />+<policy domain="coder" rights="read" pattern="PDF" />+g' /etc/ImageMagick/policy.xml && \
-
+    sed -i 's+<policy domain="coder" rights="none" pattern="PDF" />+<policy domain="coder" rights="read" pattern="PDF" />+g' /etc/ImageMagick-6/policy.xml && \
+    \
     # clean up
     rm -rf /var/lib/apt/lists/* && \
     truncate -s 0 /var/log/*log
 
-ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libjemalloc.so.1
-
 RUN mkdir -p /data && chown postgres: /data
 RUN su postgres -c "PGDATA=/data /usr/lib/postgresql/9.4/bin/initdb"
-

--- a/build/README.md
+++ b/build/README.md
@@ -5,12 +5,18 @@ https://quay.io/repository/springest/build
 ## How to build + push
 
 ```
-docker build -t quay.io/springest/build:2.4.5-4 .
-docker push quay.io/springest/build:2.4.5-4
+sudo docker build -t quay.io/springest/build:2.6.3-1 .
+sudo docker push quay.io/springest/build:2.6.3-1
 ```
 
 ## How to run
 
 ```
-docker run --rm -it quay.io/springest/build:2.4.5-4 /bin/bash
+docker run --rm -it quay.io/springest/build:2.6.3-1 /bin/bash
+```
+
+## Pull existing image
+
+```
+sudo docker pull quay.io/springest/build:2.6.3-1
 ```

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,32 +1,32 @@
-FROM ubuntu:14.04
-MAINTAINER Tim Flapper <tim@springest.com>
+FROM ubuntu:18.04
+MAINTAINER Springest <developers@springest.com>
 
-# Inspired by cloudgear ubuntu image (https://github.com/cloudgear-images/ubuntu)
-# Inspired by cloudgear ruby image (https://github.com/cloudgear-images/ruby)
-
-RUN locale-gen en_US.UTF-8 && \
-    update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8 && \
-    # Don't install man documents for future packages and remove existing
-    printf "path-exclude /usr/share/doc/*\npath-exclude /usr/share/man/*\npath-exclude /usr/share/info/*\npath-exclude /usr/share/lintian/*" >> /etc/dpkg/dpkg.cfg.d/nodoc && \
+RUN printf "path-exclude /usr/share/doc/*\npath-exclude /usr/share/man/*\npath-exclude /usr/share/info/*\npath-exclude /usr/share/lintian/*" >> /etc/dpkg/dpkg.cfg.d/nodoc && \
     cd /usr/share && rm -fr doc/* man/* info/* lintian/*
 
 ENV LANG      en_US.UTF-8
 ENV LANGUAGE  en_US.UTF-8
 ENV LC_ALL    en_US.UTF-8
 
-ENV RUBY_VERSION 2.4
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -q && apt-get install -yq --no-install-recommends ca-certificates apt-transport-https gnupg locales curl && \
+    locale-gen en_US.UTF-8 && \
+    echo deb https://apt.fullstaqruby.org ubuntu-18.04 main > /etc/apt/sources.list.d/fullstaq-ruby.list && \
+    curl -SLfO https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-server-edition/master/fullstaq-ruby.asc && \
+    apt-key add fullstaq-ruby.asc && \
+    apt update && \
+    apt-get install -yq --no-install-recommends fullstaq-ruby-2.6.3-jemalloc
+
+# Pick up new ruby/gem binaries
+ENV PATH="/usr/lib/fullstaq-ruby/versions/2.6.3-jemalloc/bin:${PATH}"
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 && \
-    echo deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main > /etc/apt/sources.list.d/pgdg.list && \
+    echo deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main > /etc/apt/sources.list.d/pgdg.list && \
     mkdir -p /usr/share/man/man1 && mkdir -p /usr/share/man/man7 && \
-    echo deb http://ppa.launchpad.net/brightbox/ruby-ng/ubuntu trusty main > /etc/apt/sources.list.d/brightbox-ruby-ng-trusty.list && \
-    \
+    curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     apt-get update -q && apt-get upgrade -yq --no-install-recommends && \
-    apt-get install -yq --no-install-recommends ca-certificates curl && \
-    \
-    curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    \
-    apt-get update -q && apt-get install -yq --no-install-recommends \
+			apt-get install -yq --no-install-recommends \
       autoconf \
       g++ \
       gcc \
@@ -46,8 +46,6 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 &
       libxslt-dev \
       libyaml-dev \
       zlib1g-dev \
-      ruby$RUBY_VERSION \
-      ruby$RUBY_VERSION-dev \
       build-essential \
       imagemagick \
       libjpeg-dev \
@@ -61,11 +59,9 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 &
       supervisor \
       postgresql-client-9.4 \
       libpq-dev \
-      libjemalloc-dev \
       ghostscript \
       poppler-utils \
       tesseract-ocr && \
-    \
     rm -rf /usr/share/man/man1 && \
     rm -rf /usr/share/man/man7 && \
     \
@@ -74,7 +70,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 &
     gem install bundler && \
     \
     # Update ImageMagick policy to allow `convert` to convert PDF files to TIFF for OCR
-    sed -i 's+<policy domain="coder" rights="none" pattern="PDF" />+<policy domain="coder" rights="read" pattern="PDF" />+g' /etc/ImageMagick/policy.xml && \
+    sed -i 's+<policy domain="coder" rights="none" pattern="PDF" />+<policy domain="coder" rights="read" pattern="PDF" />+g' /etc/ImageMagick-6/policy.xml && \
     \
     # clean up
     rm -rf /var/lib/apt/lists/* && \

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 &
     curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     apt-get update -q && apt-get upgrade -yq --no-install-recommends && \
 			apt-get install -yq --no-install-recommends \
+      tzdata \
       autoconf \
       g++ \
       gcc \

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -7,12 +7,12 @@ https://quay.io/repository/springest/ruby
 ## How to build + push
 
 ```
-docker build -t quay.io/springest/ruby:2.4.5-1 .
-docker push quay.io/springest/ruby:2.4.5-1
+sudo docker build -t quay.io/springest/ruby:2.6.3-1 .
+sudo docker push quay.io/springest/ruby:2.6.3-1
 ```
 
 ## How to run
 
 ```
-docker run --rm -it quay.io/springest/ruby:2.4.5-1 /bin/bash
+docker run --rm -it quay.io/springest/ruby:2.6.3-1 /bin/bash
 ```


### PR DESCRIPTION
#### Changes:

* 14.04 -> 19.04
* no longer using brightbox ruby but the fullstaq ruby, we can also be
more specific and use minor versions, but for now I'm using 2.6.x.
* Removed jemalloc preload as the ruby has it builtin now
* Updated chromedriver
* Added silent flag to curl commands

#### To do

- [x] set up `--no-document`