### PR TITLE
Updated postgresql-client to v11 in ruby image

### DIFF
--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -58,7 +58,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 &
       libev-dev \
       openssl \
       supervisor \
-      postgresql-client-9.4 \
+      postgresql-client-11 \
       libpq-dev \
       ghostscript \
       poppler-utils \


### PR DESCRIPTION
We also need to update `postgresql-client` to 11 in the ruby (production) container, as we use `pg_dump` to retrieve all current translations