### PR TITLE
Bump system dependencies, node to 14 and chrome to 86

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -q && apt-get install -yq --no-install-recommends ca-certificates apt-transport-https gnupg locales curl && \
     locale-gen en_US.UTF-8 && \
     echo deb https://apt.fullstaqruby.org ubuntu-18.04 main > /etc/apt/sources.list.d/fullstaq-ruby.list && \
-    curl -SLfO https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-server-edition/master/fullstaq-ruby.asc && \
+    curl -SLfO https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-server-edition/main/fullstaq-ruby.asc && \
     apt-key add fullstaq-ruby.asc && \
     apt update && \
     apt-get install -yq --no-install-recommends fullstaq-ruby-2.6.5-jemalloc
@@ -24,7 +24,11 @@ ENV PATH="/usr/lib/fullstaq-ruby/versions/2.6.5-jemalloc/bin:${PATH}"
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 ABF5BD827BD9BF62 && \
     echo deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main > /etc/apt/sources.list.d/pgdg.list && \
     echo deb http://nginx.org/packages/ubuntu/ bionic nginx > /etc/apt/sources.list.d/nginx.list && \
+<<<<<<< HEAD
     echo deb http://deb.nodesource.com/node_13.x bionic main > /etc/apt/sources.list.d/nodesource.list && \
+=======
+    echo deb http://deb.nodesource.com/node_14.x bionic main > /etc/apt/sources.list.d/nodesource.list && \
+>>>>>>> e645ee3... remove chromedriver
     echo deb http://dl.yarnpkg.com/debian/ stable main > /etc/apt/sources.list.d/yarn.list && \
     mkdir -p /usr/share/man/man1 && mkdir -p /usr/share/man/man7 && \
     curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
@@ -85,13 +89,6 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 A
     # Setup Rubygems
     echo 'gem: --no-document' > /etc/gemrc && \
     gem install bundler && \
-    \
-    # Chromedriver
-    export CHROMEDRIVER_VERSION=`curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE` && \
-    curl -sOLk https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip && \
-    unzip chromedriver_linux64.zip && \
-    mv chromedriver /usr/bin/chromedriver && \
-    rm -f chromedriver_linux64.zip && \
     \
     # Install AWS CLI to local user
     curl -s "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -24,11 +24,7 @@ ENV PATH="/usr/lib/fullstaq-ruby/versions/2.6.5-jemalloc/bin:${PATH}"
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 ABF5BD827BD9BF62 && \
     echo deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main > /etc/apt/sources.list.d/pgdg.list && \
     echo deb http://nginx.org/packages/ubuntu/ bionic nginx > /etc/apt/sources.list.d/nginx.list && \
-<<<<<<< HEAD
-    echo deb http://deb.nodesource.com/node_13.x bionic main > /etc/apt/sources.list.d/nodesource.list && \
-=======
     echo deb http://deb.nodesource.com/node_14.x bionic main > /etc/apt/sources.list.d/nodesource.list && \
->>>>>>> e645ee3... remove chromedriver
     echo deb http://dl.yarnpkg.com/debian/ stable main > /etc/apt/sources.list.d/yarn.list && \
     mkdir -p /usr/share/man/man1 && mkdir -p /usr/share/man/man7 && \
     curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \

--- a/build/README.md
+++ b/build/README.md
@@ -5,18 +5,18 @@ https://quay.io/repository/springest/build
 ## How to build + push
 
 ```
-sudo docker build -t quay.io/springest/build:2.6.5-1 .
-sudo docker push quay.io/springest/build:2.6.5-1
+sudo docker build -t quay.io/springest/build:2.6.5-3 .
+sudo docker push quay.io/springest/build:2.6.5-3
 ```
 
 ## How to run
 
 ```
-docker run --rm -it quay.io/springest/build:2.6.5-1 /bin/bash
+docker run --rm -it quay.io/springest/build:2.6.5-3 /bin/bash
 ```
 
 ## Pull existing image
 
 ```
-sudo docker pull quay.io/springest/build:2.6.5-1
+sudo docker pull quay.io/springest/build:2.6.5-3
 ```

--- a/build/README.md
+++ b/build/README.md
@@ -5,18 +5,18 @@ https://quay.io/repository/springest/build
 ## How to build + push
 
 ```
-sudo docker build -t quay.io/springest/build:2.6.5-3 .
-sudo docker push quay.io/springest/build:2.6.5-3
+sudo docker build -t quay.io/springest/build:2.6.5-4 .
+sudo docker push quay.io/springest/build:2.6.5-4
 ```
 
 ## How to run
 
 ```
-docker run --rm -it quay.io/springest/build:2.6.5-3 /bin/bash
+docker run --rm -it quay.io/springest/build:2.6.5-4 /bin/bash
 ```
 
 ## Pull existing image
 
 ```
-sudo docker pull quay.io/springest/build:2.6.5-3
+sudo docker pull quay.io/springest/build:2.6.5-4
 ```

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -13,7 +13,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -q && apt-get install -yq --no-install-recommends ca-certificates apt-transport-https gnupg locales curl && \
     locale-gen en_US.UTF-8 && \
     echo deb https://apt.fullstaqruby.org ubuntu-18.04 main > /etc/apt/sources.list.d/fullstaq-ruby.list && \
-    curl -SLfO https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-server-edition/master/fullstaq-ruby.asc && \
+    curl -SLfO https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-server-edition/main/fullstaq-ruby.asc && \
     apt-key add fullstaq-ruby.asc && \
     apt update && \
     apt-get install -yq --no-install-recommends fullstaq-ruby-2.6.5-jemalloc

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -7,12 +7,12 @@ https://quay.io/repository/springest/ruby
 ## How to build + push
 
 ```
-sudo docker build -t quay.io/springest/ruby:2.6.5-1 .
-sudo docker push quay.io/springest/ruby:2.6.5-1
+sudo docker build -t quay.io/springest/ruby:2.6.5-3 .
+sudo docker push quay.io/springest/ruby:2.6.5-3
 ```
 
 ## How to run
 
 ```
-docker run --rm -it quay.io/springest/ruby:2.6.5-1 /bin/bash
+docker run --rm -it quay.io/springest/ruby:2.6.5-3 /bin/bash
 ```

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -7,12 +7,12 @@ https://quay.io/repository/springest/ruby
 ## How to build + push
 
 ```
-sudo docker build -t quay.io/springest/ruby:2.6.5-3 .
-sudo docker push quay.io/springest/ruby:2.6.5-3
+sudo docker build -t quay.io/springest/ruby:2.6.5-4 .
+sudo docker push quay.io/springest/ruby:2.6.5-4
 ```
 
 ## How to run
 
 ```
-docker run --rm -it quay.io/springest/ruby:2.6.5-3 /bin/bash
+docker run --rm -it quay.io/springest/ruby:2.6.5-4 /bin/bash
 ```


### PR DESCRIPTION
This PR is the result of the quarterly security-audit that most of the time updates a lot of system dependencies but now also bumps nodejs to 14 (was 13 a non-LTS version) and automatically Google Chrome to 86