### PR TITLE
Add clamav to the Ruby container

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -83,6 +83,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 A
       clamdscan && \
     rm -rf /usr/share/man/man1 && \
     rm -rf /usr/share/man/man7 && \
+    # adding clamav socket directory to allow clamd to start without using a service
     mkdir -p  /run/clamav && \
     chown clamav /run/clamav && \
     \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -78,9 +78,13 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 A
       python-dev \
       ghostscript \
       poppler-utils \
-      tesseract-ocr && \
+      tesseract-ocr \
+      clamav-daemon \
+      clamdscan && \
     rm -rf /usr/share/man/man1 && \
     rm -rf /usr/share/man/man7 && \
+    mkdir -p  /run/clamav && \
+    chown clamav /run/clamav && \
     \
     # Setup Rubygems
     echo 'gem: --no-document' > /etc/gemrc && \

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -63,8 +63,8 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 &
       ghostscript \
       poppler-utils \
       tesseract-ocr \
-      clamav \
-      clamav-daemon && \
+      clamav-daemon \
+      clamdscan && \
     rm -rf /usr/share/man/man1 && \
     rm -rf /usr/share/man/man7 && \
     \

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -62,7 +62,9 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 &
       libpq-dev \
       ghostscript \
       poppler-utils \
-      tesseract-ocr && \
+      tesseract-ocr \
+      clamav \
+      clamav-daemon && \
     rm -rf /usr/share/man/man1 && \
     rm -rf /usr/share/man/man7 && \
     \

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -67,6 +67,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 &
       clamdscan && \
     rm -rf /usr/share/man/man1 && \
     rm -rf /usr/share/man/man7 && \
+    # adding clamav socket directory to allow clamd to start without using a service
     mkdir -p  /run/clamav && \
     chown clamav /run/clamav && \
     \

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -67,6 +67,8 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 &
       clamdscan && \
     rm -rf /usr/share/man/man1 && \
     rm -rf /usr/share/man/man7 && \
+    mkdir -p  /run/clamav && \
+    chown clamav /run/clamav && \
     \
     # Setup Rubygems
     echo 'gem: --no-document' > /etc/gemrc && \


### PR DESCRIPTION
This PR adds the clamav virusscanner to the ruby container. The clamav eco-system consists of two parts:
* The daemon: installed on the container and will be used for scanning the actual files. Currently the daemon will be started on web tiers next to puma
* The refresher: installed on the host to keep the virus definition database up-to-date and allows the container to instantly start with an up-to-date database, the database files are mounted into the container to persist it over multiple deploys