### PR TITLE
Update clamav config to use clustered clamav server

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -78,19 +78,9 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 A
       python-dev \
       ghostscript \
       poppler-utils \
-      tesseract-ocr \
-      clamav-daemon \
-      clamdscan && \
+      tesseract-ocr && \
     rm -rf /usr/share/man/man1 && \
     rm -rf /usr/share/man/man7 && \
-    sed -i 's/^\bLocalSocket\b/#&/g' /etc/clamav/clamd.conf && \
-    echo "TCPSocket 3310" >> /etc/clamav/clamd.conf && \
-    echo "TCPAddr 10.21.4.150" >> /etc/clamav/clamd.conf && \
-    echo "TCPAddr 10.21.5.150" >> /etc/clamav/clamd.conf && \
-    # adding clamav socket directory to allow clamd to start without using a service
-    mkdir -p  /run/clamav && \
-    chown clamav /run/clamav && \
-    \
     # Setup Rubygems
     echo 'gem: --no-document' > /etc/gemrc && \
     gem install bundler && \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -83,6 +83,10 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 A
       clamdscan && \
     rm -rf /usr/share/man/man1 && \
     rm -rf /usr/share/man/man7 && \
+    sed -i 's/^\bLocalSocket\b/#&/g' /etc/clamav/clamd.conf && \
+    echo "TCPSocket 3310" >> /etc/clamav/clamd.conf && \
+    echo "TCPAddr 10.21.4.150" >> /etc/clamav/clamd.conf && \
+    echo "TCPAddr 10.21.5.150" >> /etc/clamav/clamd.conf && \
     # adding clamav socket directory to allow clamd to start without using a service
     mkdir -p  /run/clamav && \
     chown clamav /run/clamav && \

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -67,6 +67,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 &
       clamdscan && \
     rm -rf /usr/share/man/man1 && \
     rm -rf /usr/share/man/man7 && \
+    # clamav is configured in local mode by default, disabling LocalSocket and adding TCPAddr to move it into networked mode
     sed -i 's/^\bLocalSocket\b/#&/g' /etc/clamav/clamd.conf && \
     echo "TCPSocket 3310" >> /etc/clamav/clamd.conf && \
     echo "TCPAddr 10.21.4.150" >> /etc/clamav/clamd.conf && \

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -67,6 +67,10 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 &
       clamdscan && \
     rm -rf /usr/share/man/man1 && \
     rm -rf /usr/share/man/man7 && \
+    sed -i 's/^\bLocalSocket\b/#&/g' /etc/clamav/clamd.conf && \
+    echo "TCPSocket 3310" >> /etc/clamav/clamd.conf && \
+    echo "TCPAddr 10.21.4.150" >> /etc/clamav/clamd.conf && \
+    echo "TCPAddr 10.21.5.150" >> /etc/clamav/clamd.conf && \
     # adding clamav socket directory to allow clamd to start without using a service
     mkdir -p  /run/clamav && \
     chown clamav /run/clamav && \


### PR DESCRIPTION
Previously we were running our own clamav-daemon per instance, this PR sets the daemon to listen to the clustered clamav server.

By default `clamdscan` is using local mode, meaning listening to a unix socket to serve its own virus definition database. With [Stackest PR #64](https://github.com/Springest/stackest/pull/64), the `clamav-server` is hosted on its own, this PR updates the default configuration to listen to the new hosted `clamav-server`