### PR TITLE
Upgraded python to 3.x

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -75,7 +75,8 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 A
       google-chrome-stable \
       libpq-dev \
       nginx \
-      python-dev \
+      python3-dev \
+      python3-pip \
       ghostscript \
       poppler-utils \
       tesseract-ocr && \
@@ -86,11 +87,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 A
     gem install bundler && \
     \
     # Install AWS CLI to local user
-    curl -s "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
-    unzip awscli-bundle.zip && \
-    ./awscli-bundle/install -b ~/bin/aws && \
-    rm awscli-bundle.zip && \
-    rm -r awscli-bundle && \
+    pip3 install awscli && \
     \
     # Update ImageMagick policy to allow `convert` to convert PDF files to TIFF for OCR
     sed -i 's+<policy domain="coder" rights="none" pattern="PDF" />+<policy domain="coder" rights="read" pattern="PDF" />+g' /etc/ImageMagick-6/policy.xml && \

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -17,7 +17,7 @@ ENV LC_ALL    en_US.UTF-8
 ENV RUBY_VERSION 2.4
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 && \
-    echo deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main > /etc/apt/sources.list.d/pgdg.list && \
+    echo deb https://apt-archive.postgresql.org/pub/repos/apt/ trusty-pgdg main > /etc/apt/sources.list.d/pgdg.list && \
     mkdir -p /usr/share/man/man1 && mkdir -p /usr/share/man/man7 && \
     echo deb http://ppa.launchpad.net/brightbox/ruby-ng/ubuntu trusty main > /etc/apt/sources.list.d/brightbox-ruby-ng-trusty.list && \
     apt-get update -q && apt-get install -yq --no-install-recommends ca-certificates curl \
@@ -32,16 +32,13 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C3173AA6 &
       build-essential \
       git \
       procps \
-      python-dev \
-      python-pip \
+      python3-dev \
+      python3-pip \
       jq && \
     rm -rf /usr/share/man/man1 && \
     rm -rf /usr/share/man/man7 && \
     # Install AWS CLI
-    python -m pip install -U pip && \
-    pip install -U six && \
-    pip install awscli && \
-    pip install awsebcli && \
+    pip3 install awscli && \
     # clean up
     rm -rf /var/lib/apt/lists/* && \
     truncate -s 0 /var/log/*log


### PR DESCRIPTION
- The build for release fails because `aws-cli-1` gives error due to unsupported `python`.
- The deploy fails both for python and archived postgres package

https://github.com/Springest/docker-containers/runs/5973739095?check_suite_focus=true#step:4:2656
![](https://cln.sh/PwFHz6VhzVUCX2Xu62gx+)